### PR TITLE
Add support to model classes on `mockResponse` dsl

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,8 +24,13 @@ mockk = "1.13.5"
 gson = "2.11.0"
 
 [libraries]
+#noinspection SimilarGradleDependency
 agp420 = { module = "com.android.tools.build:gradle", version = "4.2.0" }
+
+#noinspection SimilarGradleDependency
 agp710 = { module = "com.android.tools.build:gradle", version = "7.1.0" }
+
+#noinspection SimilarGradleDependency
 agp722 = { module = "com.android.tools.build:gradle", version = "7.2.2" }
 
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/iris-mock/src/main/kotlin/dev/arildo/iris/mock/dsl/MockDsl.kt
+++ b/iris-mock/src/main/kotlin/dev/arildo/iris/mock/dsl/MockDsl.kt
@@ -35,16 +35,14 @@ infix fun InterceptedRequest.mockResponse(response: String) {
  * ```
  * // sample
  * override fun intercept(chain: Chain) = irisMock(chain) {
- *     onGet("/image") mockResponse mapOf("imageUrl" to "https://imageurl.com")
+ *     onGet("/image") mockResponse MyModel()
  *     // or
- *     onGet("/image") {
- *         mapOf("imageUrl" to "https://imageurl.com")
- *     }
+ *     onGet("/image") mockResponse mapOf("imageUrl" to "https://imageurl.com")
  * }
  * ```
  *  @param response used as response body
  */
-infix fun InterceptedRequest.mockResponse(response: Map<String, Any?>) {
+infix fun InterceptedRequest.mockResponse(response: Any) {
     if (shouldIntercept) {
         IrisMock.logger.info("Mocking Response: [$method] $url")
 

--- a/iris-mock/src/test/kotlin/dev/arildo/iris/mock/dsl/MockDslTest.kt
+++ b/iris-mock/src/test/kotlin/dev/arildo/iris/mock/dsl/MockDslTest.kt
@@ -31,7 +31,7 @@ class MockDslTest {
     }
 
     @Test
-    fun `when use custom response extension, then return correct json response`() {
+    fun `when use mockResponse map, then return correct json response`() {
         val expectedJson = "{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value4\"}"
 
         irisMock(chainMock) {
@@ -49,4 +49,34 @@ class MockDslTest {
             IrisMock.callModifiers.elementAt(0)
         )
     }
+
+    @Test
+    fun `when use mockResponse string, then return correct json response`() {
+        val expectedJson = "{\"id\":2,\"name\":\"Arildo\"}"
+
+        irisMock(chainMock) {
+            onGet("user/me").mockResponse(expectedJson)
+        }
+
+        assertEquals(
+            CustomResponseBodyModifier(chainMock.hashCode(), expectedJson),
+            IrisMock.callModifiers.elementAt(0)
+        )
+    }
+
+    @Test
+    fun `when use mockResponse model class, then return correct json response`() {
+        val expectedJson = "{\"id\":2,\"name\":\"Arildo\"}"
+
+        irisMock(chainMock) {
+            onGet("user/me").mockResponse(ModelTest(id = 2, name = "Arildo"))
+        }
+
+        assertEquals(
+            CustomResponseBodyModifier(chainMock.hashCode(), expectedJson),
+            IrisMock.callModifiers.elementAt(0)
+        )
+    }
+
+    private data class ModelTest(val id: Int, val name: String)
 }


### PR DESCRIPTION
### Description 
This PR adds support to receive object classes on `mockResponse()` dsl function, that serializes the object internally.

#### Usage
```kotlin
data class MyModel(val name: String, val age: Int)

override fun intercept(chain: Chain) = irisMock(chain) {
    onGet("/image") mockResponse MyModel()
}

```

